### PR TITLE
Dispatcher performance

### DIFF
--- a/VueFlux/Internal/Dispatcher.swift
+++ b/VueFlux/Internal/Dispatcher.swift
@@ -1,5 +1,5 @@
 /// An action dispatcher for subscribed dispatch functions.
-struct Dispatcher<State: VueFlux.State> {
+final class Dispatcher<State: VueFlux.State> {
     typealias Observers = Storage<(State.Action) -> Void>
     
     /// Shared instance associated by generic type of State.

--- a/VueFlux/Internal/DispatcherContext.swift
+++ b/VueFlux/Internal/DispatcherContext.swift
@@ -2,7 +2,7 @@
 struct DispatcherContext {
     static let shared = DispatcherContext()
     
-    private let dispatchers = AtomicReference([Identifier: Any]())
+    private let dispatchers = AtomicReference([ObjectIdentifier: Any]())
     
     private init() {}
     
@@ -14,7 +14,7 @@ struct DispatcherContext {
     /// - Returns: An shared instance of Dispatcher.
     func dispatcher<State: VueFlux.State>(for stateType: State.Type) -> Dispatcher<State> {
         return dispatchers.modify { dispatchers in
-            let identifier = Identifier(for: stateType)
+            let identifier = ObjectIdentifier(stateType)
             if let dispatcher = dispatchers[identifier] as? Dispatcher<State> {
                 return dispatcher
             }
@@ -22,31 +22,6 @@ struct DispatcherContext {
             let dispatcher = Dispatcher<State>()
             dispatchers[identifier] = dispatcher
             return dispatcher
-        }
-    }
-}
-
-private extension DispatcherContext {
-    /// Identifier for save dispatcher instance.
-    struct Identifier: Hashable {
-        let hashValue: Int
-        
-        /// Create with arbitrary State protocol conformed type.
-        /// - Parameters:
-        ///   - stateType: Type of state to make Dispatcher unique.
-        init<State: VueFlux.State>(for stateType: State.Type) {
-            hashValue = String(reflecting: stateType).hashValue
-        }
-        
-        /// Compare whether two identifiers are equal.
-        ///
-        /// - Parameters:
-        ///   - lhs: An identifier to compare.
-        ///   - rhs: Another identifier to compare.
-        ///
-        /// - Returns: A Bool value indicating whether two identifiers are equal.
-        static func == (lhs: Identifier, rhs: Identifier) -> Bool {
-            return lhs.hashValue == rhs.hashValue
         }
     }
 }


### PR DESCRIPTION
Performance of retrieving Dispatcher shared instance improved 3x or more.

- Class based Dispatcher
- Use ObjectIdentifier instead of DispatcherContext.Identifier 