### PR TITLE
Fix Segmentation fault error in Swift4.1

### DIFF
--- a/VueFlux/Executor.swift
+++ b/VueFlux/Executor.swift
@@ -18,7 +18,7 @@ public struct Executor {
     
     /// All the executions are enqueued to given qeueue.
     public static func queue(_ dispatchQueue: DispatchQueue) -> Executor {
-        return .init { function in dispatchQueue.async(execute: function) }
+        return .init { function in dispatchQueue.async { function() } }
     }
     
     private let context: Context


### PR DESCRIPTION
Fixed #24 

It seems that an error has occurred due to a compiler bug.
So I avoided this error by changing only the description method.
Build succeeded in the following environment.

**[Environment]** Xcode9.3, Swift4.1

