### PR TITLE
Remove unnecessary `State` constraint for reusability

### DIFF
--- a/Example/Sources/CounterActions.swift
+++ b/Example/Sources/CounterActions.swift
@@ -9,7 +9,7 @@ enum CounterAction {
     case update(interval: TimeInterval)
 }
 
-extension Actions where State == CounterState {
+extension Actions where Action == CounterAction {
     func incrementAcync(after interval: TimeInterval = 0) {
         DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + interval) {
             self.dispatch(action: .increment)

--- a/Example/Sources/CounterState.swift
+++ b/Example/Sources/CounterState.swift
@@ -20,10 +20,7 @@ extension Computed where State == CounterState {
     }
 }
 
-final class CounterState: State {
-    typealias Action = CounterAction
-    typealias Mutations = CounterMutations
-    
+final class CounterState {
     enum Command {
         case openGitHub
     }

--- a/Example/Sources/CounterViewController.swift
+++ b/Example/Sources/CounterViewController.swift
@@ -6,7 +6,7 @@ import VueFluxReactive
 final class CounterViewController: UIViewController {
     @IBOutlet private weak var counterView: CounterView!
     
-    private let store = Store<CounterState>(state: .init(max: 1000), mutations: .init(), executor: .queue(.global()))
+    private let store = Store<CounterState, CounterAction>(state: .init(max: 1000), mutations: CounterMutations(), executor: .queue(.global()))
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent

--- a/VueFlux/Internal/Dispatcher.swift
+++ b/VueFlux/Internal/Dispatcher.swift
@@ -1,9 +1,9 @@
 /// An action dispatcher for subscribed dispatch functions.
-final class Dispatcher<State: VueFlux.State> {
-    typealias Observers = Storage<(State.Action) -> Void>
+final class Dispatcher<State, Action> {
+    typealias Observers = Storage<(Action) -> Void>
     
     /// Shared instance associated by generic type of State.
-    static var shared: Dispatcher<State> {
+    static var shared: Dispatcher<State, Action> {
         return DispatcherContext.shared.dispatcher(for: State.self)
     }
     
@@ -17,7 +17,7 @@ final class Dispatcher<State: VueFlux.State> {
     ///
     /// - Parameters:
     ///   - action: An Action to be dispatch.
-    func dispatch(action: State.Action) {
+    func dispatch(action: Action) {
         dispatchLock.lock()
         defer { dispatchLock.unlock() }
         
@@ -33,7 +33,7 @@ final class Dispatcher<State: VueFlux.State> {
     ///
     /// - Returns: A key for remove given observer.
     @discardableResult
-    func subscribe(_ observer: @escaping (State.Action) -> Void) -> Observers.Key {
+    func subscribe(_ observer: @escaping (Action) -> Void) -> Observers.Key {
         return observers.modify { observers in
             observers.add(observer)
         }

--- a/VueFlux/Internal/Dispatcher.swift
+++ b/VueFlux/Internal/Dispatcher.swift
@@ -4,7 +4,7 @@ final class Dispatcher<State, Action> {
     
     /// Shared instance associated by generic type of State.
     static var shared: Dispatcher<State, Action> {
-        return DispatcherContext.shared.dispatcher(for: State.self)
+        return DispatcherContext.shared.dispatcher(for: Dispatcher<State, Action>.self)
     }
     
     private let dispatchLock = Lock(recursive: true)

--- a/VueFlux/Internal/DispatcherContext.swift
+++ b/VueFlux/Internal/DispatcherContext.swift
@@ -12,9 +12,9 @@ struct DispatcherContext {
     ///   - stateType: State protocol conformed type for Dispatcher.
     ///
     /// - Returns: An shared instance of Dispatcher.
-    func dispatcher<State, Action>(for stateType: State.Type) -> Dispatcher<State, Action> {
+    func dispatcher<State, Action>(for dispatcherType: Dispatcher<State, Action>.Type) -> Dispatcher<State, Action> {
         return dispatchers.modify { dispatchers in
-            let identifier = ObjectIdentifier(stateType)
+            let identifier = ObjectIdentifier(dispatcherType)
             if let dispatcher = dispatchers[identifier] as? Dispatcher<State, Action> {
                 return dispatcher
             }

--- a/VueFlux/Internal/DispatcherContext.swift
+++ b/VueFlux/Internal/DispatcherContext.swift
@@ -12,14 +12,14 @@ struct DispatcherContext {
     ///   - stateType: State protocol conformed type for Dispatcher.
     ///
     /// - Returns: An shared instance of Dispatcher.
-    func dispatcher<State: VueFlux.State>(for stateType: State.Type) -> Dispatcher<State> {
+    func dispatcher<State, Action>(for stateType: State.Type) -> Dispatcher<State, Action> {
         return dispatchers.modify { dispatchers in
             let identifier = ObjectIdentifier(stateType)
-            if let dispatcher = dispatchers[identifier] as? Dispatcher<State> {
+            if let dispatcher = dispatchers[identifier] as? Dispatcher<State, Action> {
                 return dispatcher
             }
             
-            let dispatcher = Dispatcher<State>()
+            let dispatcher = Dispatcher<State, Action>()
             dispatchers[identifier] = dispatcher
             return dispatcher
         }

--- a/VueFlux/VueFlux.swift
+++ b/VueFlux/VueFlux.swift
@@ -1,5 +1,5 @@
 /// Manages a State and commits the action received via dispatcher to mutations.
-open class Store<State, Action> {
+open class Store<State: AnyObject, Action> {
     private let dispatcher = Dispatcher<State, Action>()
     private let sharedDispatcher = Dispatcher<State, Action>.shared
     


### PR DESCRIPTION
This is just an example code to improve framework's type signatures.
(Note: Test fixes are not included)

- `State` should not be constrained by any protocols (especially with associated type). Otherwise, it won't be reusable and composable when making a larger state. 
- Same can be said for `Action` which should be isolated from `State`.
- Only `Mutation` should be the protocol that associates both `State` and `Action` 
- `extension Actions where Action == CounterAction` is more intuitive to make an extension compared to `extension Actions where State == CounterState`, where `CounterAction` is implicitly associated inside `CounterState`.
